### PR TITLE
Added chests to MapRenderer

### DIFF
--- a/Helpers/MapRenderer.cs
+++ b/Helpers/MapRenderer.cs
@@ -40,6 +40,12 @@ namespace D2RAssist.Helpers
             public static readonly Bitmap DoorPrevious = CreateFilledRectangle(Settings.Map.Colors.DoorPrevious, 10, 10);
             public static readonly Bitmap Waypoint = CreateFilledRectangle(Settings.Map.Colors.Waypoint, 10, 10);
             public static readonly Bitmap Player = CreateFilledRectangle(Settings.Map.Colors.Player, 10, 10);
+            public static readonly Bitmap SuperChest = CreateFilledEllipse(Settings.Map.Colors.SuperChest, 10, 10);
+        }
+
+        public static class MapPointsOfInterest
+        {
+            public static readonly string[] Chests = { "5", "6", "87", "104", "105", "106", "107", "143", "140", "141", "144", "146", "147", "148", "176", "177", "181", "183", "198", "240", "241", "242", "243", "329", "330", "331", "332", "333", "334", "335", "336", "354", "355", "356", "371", "387", "389", "390", "391", "397", "405", "406", "407", "413", "420", "424", "425", "430", "431", "432", "433", "454", "455", "501", "502", "504", "505", "580", "581", };
         }
 
         private static Bitmap CreateFilledRectangle(Color color, int width, int height)
@@ -48,6 +54,16 @@ namespace D2RAssist.Helpers
             Graphics graphics = Graphics.FromImage(rectangle);
             graphics.SmoothingMode = SmoothingMode.AntiAlias;
             graphics.FillRectangle(new SolidBrush(color), 0, 0, width, height);
+            graphics.Dispose();
+            return rectangle;
+        }
+
+        private static Bitmap CreateFilledEllipse(Color color, int width, int height)
+        {
+            Bitmap rectangle = new Bitmap(width, height, PixelFormat.Format32bppArgb);
+            Graphics graphics = Graphics.FromImage(rectangle);
+            graphics.SmoothingMode = SmoothingMode.AntiAlias;
+            graphics.FillEllipse(new SolidBrush(color), 0, 0, width, height);
             graphics.Dispose();
             return rectangle;
         }
@@ -192,6 +208,10 @@ namespace D2RAssist.Helpers
                 else if ((string)mapObject.Key == "152" || (string)mapObject.Key == "357" || (string)mapObject.Key == "356" || (string)mapObject.Key == "354" || (string)mapObject.Key == "355" || (string)mapObject.Key == "266")
                 {
                     CachedBackgroundGraphics.DrawImage(Icons.DoorNext, mapObjectPoint);
+                }
+                else if (MapPointsOfInterest.Chests.Contains((string)mapObject.Key))
+                {
+                    CachedBackgroundGraphics.DrawImage(Icons.SuperChest, mapObjectPoint);
                 }
             }
 


### PR DESCRIPTION
Borrowed some chestIDs from kolbot, and tested on Lower Kurast. Shows all the chests in the area as green ellipses

https://github.com/blizzhackers/kolbot/blob/d9dfd6137bd0f2a19204c99599861d46bc1b6da4/d2bs/kolbot/libs/common/Misc.js#L965