### PR TITLE
Change default UpdateTime to 150ms

### DIFF
--- a/App.config
+++ b/App.config
@@ -14,7 +14,7 @@
     <appSettings>
         <add key="ApiEndpoint" value="http://localhost:8080/"></add>
         <add key="Opacity" value="0.7"></add>
-        <add key="UpdateTime" value="750"></add>
+        <add key="UpdateTime" value="150"></add>
         <add key="HideInTown" value="true"></add>
         <add key="ToggleViaInGameMap" value="true"></add>
     </appSettings>

--- a/frmOverlay.cs
+++ b/frmOverlay.cs
@@ -139,7 +139,8 @@ namespace D2RAssist
 
         private void mapOverlay_Paint(object sender, PaintEventArgs e)
         {
-            if (Globals.MapData == null)
+            // Handle race condition where mapData hasn't been received yet.
+            if (Globals.MapData == null || Globals.MapData.mapRows[0].Length == 0)
             {
                 return;
             }


### PR DESCRIPTION
- Changes config for default UpdateTime
- Fixes race condition where mapData hasn't been received yet but it is trying to render the image