### PR TITLE
Added HiddenAreas, where Map should always be hidden.

### DIFF
--- a/App.config
+++ b/App.config
@@ -27,6 +27,7 @@
         <add key="ToggleKey" value="\" />
         <add key="ClearPrefetchedOnAreaChange" value="false" />
         <add key="PrefetchAreas" value="Catacombs Level 2,Durance Of Hate Level 2" />
+        <add key="HiddenAreas" value="Forgotten Tower" />
 
         <add key="Waypoint.IconColor" value="16, 140, 235" />
         <add key="Waypoint.IconShape" value="Rectangle" />

--- a/Overlay.cs
+++ b/Overlay.cs
@@ -138,6 +138,7 @@ namespace D2RAssist
             if (!_show) return true;
             if (_currentGameData.Area == Area.None) return true;
             if (Settings.Map.HideInTown && _currentGameData.Area.IsTown()) return true;
+            if (Array.Exists(Settings.Map.HiddenAreas, element => element == _currentGameData.Area)) return true;
             if (!InGame()) return true;
             if (Settings.Map.ToggleViaInGameMap && !_currentGameData.MapShown) return true;
             return false;

--- a/Types/Settings.cs
+++ b/Types/Settings.cs
@@ -114,6 +114,9 @@ namespace D2RAssist.Types
             public static Area[] PrefetchAreas =
                 Utils.ParseCommaSeparatedAreasByName(ConfigurationManager.AppSettings["PrefetchAreas"]);
 
+            public static Area[] HiddenAreas =
+                Utils.ParseCommaSeparatedAreasByName(ConfigurationManager.AppSettings["HiddenAreas"]);
+
             public static bool ClearPrefetchedOnAreaChange =
                 Convert.ToBoolean(ConfigurationManager.AppSettings["ClearPrefetchedOnAreaChange"]);
         }


### PR DESCRIPTION
crashed my branch, resubmit

There was also the idea to deprecate IsTown later and list the towns here.
Actually there is no reason to include the towns in customization and not hardcode them, as the overlay cannot provide additional information at the moment and the town map is always revealed.
In the future, it migth be possible to completely replace the ingame map und just remove towns from config, instead of re-code.
But removing IsTown would still reduce code.