### PR TITLE
Add back in CustomAssemblyName but only if it's set

### DIFF
--- a/D2RAssist.csproj
+++ b/D2RAssist.csproj
@@ -8,8 +8,9 @@
         <ProjectGuid>{FB3AC437-B7BB-42FF-A2A2-F10551F95F6C}</ProjectGuid>
         <OutputType>WinExe</OutputType>
         <RootNamespace>D2RAssist</RootNamespace>
-        <AssemblyName Condition=" '$(Configuration)' == 'Release' ">$(RandomGuid)</AssemblyName>
-        <AssemblyName Condition=" '$(Configuration)' == 'Debug' ">D2RAssist</AssemblyName>
+        <AssemblyName Condition=" '$(CustomAssemblyName)' != '' ">'$(CustomAssemblyName)'</AssemblyName>
+        <AssemblyName Condition=" '$(Configuration)' == 'Release' AND '$(CustomAssemblyName)' == '' ">$(RandomGuid)</AssemblyName>
+        <AssemblyName Condition=" '$(Configuration)' == 'Debug' AND '$(CustomAssemblyName)' == ''">D2RAssist</AssemblyName>
         <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
         <FileAlignment>512</FileAlignment>
         <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>


### PR DESCRIPTION
Easy one, allows people that compile their own to set the env var `CustomAssemblyName` and it'll output it as that.